### PR TITLE
fix case sensitive value for Dynamic IP allocation

### DIFF
--- a/articles/virtual-machines/linux/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/linux/terraform-create-complete-vm.md
@@ -92,7 +92,7 @@ resource "azurerm_public_ip" "myterraformpublicip" {
     name                         = "myPublicIP"
     location                     = "eastus"
     resource_group_name          = "${azurerm_resource_group.myterraformgroup.name}"
-    allocation_method            = "dynamic"
+    allocation_method            = "Dynamic"
 
     tags {
         environment = "Terraform Demo"
@@ -142,7 +142,7 @@ resource "azurerm_network_interface" "myterraformnic" {
     ip_configuration {
         name                          = "myNicConfiguration"
         subnet_id                     = "${azurerm_subnet.myterraformsubnet.id}"
-        private_ip_address_allocation = "dynamic"
+        private_ip_address_allocation = "Dynamic"
         public_ip_address_id          = "${azurerm_public_ip.myterraformpublicip.id}"
     }
 
@@ -284,7 +284,7 @@ resource "azurerm_public_ip" "myterraformpublicip" {
     name                         = "myPublicIP"
     location                     = "eastus"
     resource_group_name          = "${azurerm_resource_group.myterraformgroup.name}"
-    allocation_method            = "dynamic"
+    allocation_method            = "Dynamic"
 
     tags {
         environment = "Terraform Demo"
@@ -324,7 +324,7 @@ resource "azurerm_network_interface" "myterraformnic" {
     ip_configuration {
         name                          = "myNicConfiguration"
         subnet_id                     = "${azurerm_subnet.myterraformsubnet.id}"
-        private_ip_address_allocation = "dynamic"
+        private_ip_address_allocation = "Dynamic"
         public_ip_address_id          = "${azurerm_public_ip.myterraformpublicip.id}"
     }
 


### PR DESCRIPTION
## PR description:

Running through the current doc as is produced an error related to the case sensitivity of the allocation method for the IP:

```
Error: azurerm_public_ip.myterraformpublicip: expected allocation_method to be one of [Static Dynamic], got dynamic
```

Updating the Terraform code to upper case 'Dynamic' results in a successful run.

```
+ azurerm_public_ip.myterraformpublicip
      id:                                                                    <computed>
      allocation_method:                                                     "Dynamic"
```

Following the Terraform docs here:

[azurerm_network_interface](https://www.terraform.io/docs/providers/azurerm/r/network_interface.html#private_ip_address_allocation)

[azurerm_public_ip](https://www.terraform.io/docs/providers/azurerm/r/public_ip.html#allocation_method)

Versions:

```
› terraform version
Terraform v0.11.12
+ provider.azurerm v1.23.0
```